### PR TITLE
Quick, but dirty Tier shift 2 -> 3 and 3 -> 4

### DIFF
--- a/src/main/java/com/kaijin/AdvPowerMan/blocks/BlockAdvPwrMan.java
+++ b/src/main/java/com/kaijin/AdvPowerMan/blocks/BlockAdvPwrMan.java
@@ -278,19 +278,19 @@ public class BlockAdvPwrMan extends BlockContainer{
 			return new TEChargingBench(1);
 			
 		case 1:
-			return new TEChargingBench(2);
+			return new TEChargingBench(3);
 			
 		case 2:
-			return new TEChargingBench(3);
+			return new TEChargingBench(4);
 			
 		case 3:
 			return new TEAdvEmitter(1); // Update old emitter tier 1
 			
 		case 4:
-			return new TEAdvEmitter(2); // Update old emitter tier 2
+			return new TEAdvEmitter(3); // Update old emitter tier 2
 			
 		case 5:
-			return new TEAdvEmitter(3); // Update old emitter tier 3
+			return new TEAdvEmitter(4); // Update old emitter tier 3
 			
 		case 6:
 			return new TEAdjustableTransformer();
@@ -302,10 +302,10 @@ public class BlockAdvPwrMan extends BlockContainer{
 			return new TEBatteryStation(1);
 			
 		case 9:
-			return new TEBatteryStation(2);
+			return new TEBatteryStation(3);
 			
 		case 10:
-			return new TEBatteryStation(3);
+			return new TEBatteryStation(4);
 			
 		case 11:
 			return new TEStorageMonitor();

--- a/src/main/java/com/kaijin/AdvPowerMan/tileentities/TEBatteryStation.java
+++ b/src/main/java/com/kaijin/AdvPowerMan/tileentities/TEBatteryStation.java
@@ -8,8 +8,10 @@ import com.kaijin.AdvPowerMan.AdvancedPowerManagement;
 import com.kaijin.AdvPowerMan.Info;
 import com.kaijin.AdvPowerMan.MovingAverage;
 import com.kaijin.AdvPowerMan.Utils;
+
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ic2.api.energy.EnergyNet;
 import ic2.api.energy.event.EnergyTileLoadEvent;
 import ic2.api.energy.tile.IEnergySource;
 import ic2.api.item.ElectricItem;
@@ -68,7 +70,7 @@ public class TEBatteryStation extends TECommonBench implements IEnergySource, II
 	private void initializeValues(){
 		powerTier = baseTier;
 		// Output math = 32 for tier 1, 128 for tier 2, 512 for tier 3
-		packetSize = (int) Math.pow(2.0D, (double) (2 * baseTier + 3));
+		packetSize = (int) Math.pow(2.0D, EnergyNet.instance.getPowerFromTier(powerTier));
 		
 	}
 	
@@ -528,9 +530,9 @@ public class TEBatteryStation extends TECommonBench implements IEnergySource, II
 		switch(baseTier){
 		case 1:
 			return Info.KEY_BLOCK_NAMES[8] + Info.KEY_NAME_SUFFIX;
-		case 2:
-			return Info.KEY_BLOCK_NAMES[9] + Info.KEY_NAME_SUFFIX;
 		case 3:
+			return Info.KEY_BLOCK_NAMES[9] + Info.KEY_NAME_SUFFIX;
+		case 4:
 			return Info.KEY_BLOCK_NAMES[10] + Info.KEY_NAME_SUFFIX;
 		}
 		return "";

--- a/src/main/java/com/kaijin/AdvPowerMan/tileentities/TEChargingBench.java
+++ b/src/main/java/com/kaijin/AdvPowerMan/tileentities/TEChargingBench.java
@@ -745,9 +745,9 @@ public class TEChargingBench extends TECommonBench implements IEnergySink, IEner
 		switch(baseTier){
 		case 1:
 			return Info.KEY_BLOCK_NAMES[0] + Info.KEY_NAME_SUFFIX;
-		case 2:
-			return Info.KEY_BLOCK_NAMES[1] + Info.KEY_NAME_SUFFIX;
 		case 3:
+			return Info.KEY_BLOCK_NAMES[1] + Info.KEY_NAME_SUFFIX;
+		case 4:
 			return Info.KEY_BLOCK_NAMES[2] + Info.KEY_NAME_SUFFIX;
 		}
 		return "";

--- a/src/main/resources/assets/advancedpowermanagement/lang/en_US.lang
+++ b/src/main/resources/assets/advancedpowermanagement/lang/en_US.lang
@@ -1,14 +1,14 @@
 blockChargingBench1.name=LV Charging Bench
-blockChargingBench2.name=MV Charging Bench
-blockChargingBench3.name=HV Charging Bench
+blockChargingBench2.name=HV Charging Bench
+blockChargingBench3.name=EV Charging Bench
 blockEmitterBlock1.name=LV Emitter
-blockEmitterBlock2.name=MV Emitter
-blockEmitterBlock3.name=HV Emitter
+blockEmitterBlock2.name=HV Emitter
+blockEmitterBlock3.name=EV Emitter
 blockAdjustableTransformer.name=Adjustable Transformer
 blockEmitterAdjustable.name=Adjustable Emitter
 blockBatteryStation1.name=LV Battery Station
-blockBatteryStation2.name=MV Battery Station
-blockBatteryStation3.name=HV Battery Station
+blockBatteryStation2.name=HV Battery Station
+blockBatteryStation3.name=EV Battery Station
 blockStorageMonitor.name=Storage Monitor
 
 AdvPwrMan.dir.down=Down
@@ -20,8 +20,8 @@ AdvPwrMan.dir.east=East
 
 item.benchTools.toolkit.name=Charging Bench Toolkit
 item.benchTools.LV-kit.name=LV Charging Bench Components
-item.benchTools.MV-kit.name=MV Charging Bench Components
-item.benchTools.HV-kit.name=HV Charging Bench Components
+item.benchTools.MV-kit.name=HV Charging Bench Components
+item.benchTools.HV-kit.name=EV Charging Bench Components
 
 item.itemStorageLinkCard.name=Energy Link Card
 item.itemStorageLinkCardCreator.name=Energy Link Card (Blank)


### PR DESCRIPTION
Shifted the tier of machines from 2 to 3 and from 3 to 4, so the tiers are equal to MFE and MFSU again. CESU tier is now skipped.
